### PR TITLE
Fix typos in Perl version

### DIFF
--- a/META.json
+++ b/META.json
@@ -54,7 +54,7 @@
       },
       "runtime" : {
          "requires" : {
-            "perl" : "5.001001"
+            "perl" : "5.010_001"
          }
       },
       "test" : {

--- a/lib/App/dategrep.pm
+++ b/lib/App/dategrep.pm
@@ -1,5 +1,5 @@
 package App::dategrep;
-use 5.001001;
+use 5.010_001;
 use strict;
 use warnings;
 


### PR DESCRIPTION
5.001001 is v5.1 not v5.10